### PR TITLE
Fix: Show Docker build errors without requiring --verbose flag

### DIFF
--- a/packages/cli/src/docker/index.ts
+++ b/packages/cli/src/docker/index.ts
@@ -148,9 +148,10 @@ export class DockerClient {
       }
       return { stdout, stderr };
     } catch (error) {
-      if (verbose) {
-        console.error(`Local command failed: ${command}`, error);
-      }
+      // Always show command and error details for build failures, even without --verbose
+      // This ensures users can see what went wrong without needing to use --verbose flag
+      console.error(`Local command failed: ${command}`);
+      console.error(error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

- Fixed Docker build error visibility to show detailed error messages without requiring the `--verbose` flag
- Users can now see exactly what went wrong during build failures without additional flags

## Problem

Issue #64 reported that build errors were only visible when using the `--verbose` flag. Without it, users only saw generic error messages like "Failed to build service" without any details about what actually went wrong.

## Solution

Modified the `_runLocalCommand` method in `packages/cli/src/docker/index.ts` to always display command failures and error details for Docker operations, regardless of the verbose setting. This ensures users get actionable error information by default.

## Test Plan

- [x] Tested with broken Dockerfile (invalid base image) without `--verbose` - now shows detailed Docker error
- [x] Tested with working Dockerfile - build still works correctly
- [x] Verified that verbose mode still works as expected

Before:
```
[✗] Failed to build service web1
[✗] web1 image preparation failed
```

After:
```
Local command failed: docker build -f "Dockerfile" -t "web1:5ca9b1f" -t "web1:latest" --build-arg "EXAMPLE_VAR=web1" --platform "linux/amd64" "."
Error: Command failed: docker build ...
ERROR: failed to solve: nonexistent-image:latest: failed to resolve source metadata for docker.io/library/nonexistent-image:latest: pull access denied, repository does not exist or may require authorization
```

🤖 Generated with [Claude Code](https://claude.ai/code)