### PR TITLE
Fix service fingerprinting with direct Docker image inspection

### DIFF
--- a/packages/cli/src/commands/blue-green.ts
+++ b/packages/cli/src/commands/blue-green.ts
@@ -87,11 +87,8 @@ function createBlueGreenContainerOptions(
         "iop.fingerprint-type": fingerprint.type,
         "iop.config-hash": fingerprint.configHash,
         "iop.secrets-hash": fingerprint.secretsHash,
-        ...(fingerprint.type === 'built' ? {
-          ...(fingerprint.localImageHash && { "iop.local-image-hash": fingerprint.localImageHash }),
-          ...(fingerprint.serverImageHash && { "iop.server-image-hash": fingerprint.serverImageHash }),
-        } : {
-          ...(fingerprint.imageReference && { "iop.image-reference": fingerprint.imageReference }),
+        ...(fingerprint.type === 'external' && fingerprint.imageReference && { 
+          "iop.image-reference": fingerprint.imageReference 
         }),
       } : {}),
     },

--- a/packages/cli/src/utils/service-fingerprint.ts
+++ b/packages/cli/src/utils/service-fingerprint.ts
@@ -126,7 +126,8 @@ export async function createServiceFingerprint(
   
   if (isBuiltService(serviceEntry)) {
     // Built service - get local image hash directly from Docker
-    const imageName = projectName ? `${projectName}-${serviceEntry.name}` : serviceEntry.name;
+    // Use same naming convention as getServiceImageName()
+    const imageName = serviceEntry.name;
     const localImageHash = await getLocalImageHash(imageName);
     
     return {

--- a/packages/cli/src/utils/service-fingerprint.ts
+++ b/packages/cli/src/utils/service-fingerprint.ts
@@ -2,7 +2,6 @@ import * as crypto from 'crypto';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { ServiceEntry, IopSecrets } from '../config/types';
-import { SSHClient } from '../ssh';
 
 const execAsync = promisify(exec);
 
@@ -98,7 +97,7 @@ export function createSecretsHash(
  */
 export async function getLocalImageHash(imageName: string): Promise<string | null> {
   try {
-    const result = await execAsync(`docker image ls --format "{{.ID}}" ${imageName}:latest`);
+    const result = await execAsync(`docker inspect --format='{{.Id}}' ${imageName}:latest`);
     const imageId = result.stdout.trim();
     return imageId || null;
   } catch (error) {
@@ -106,22 +105,6 @@ export async function getLocalImageHash(imageName: string): Promise<string | nul
   }
 }
 
-/**
- * Gets the Docker image hash for a service running on a server
- */
-export async function getServerImageHash(
-  serviceName: string, 
-  projectName: string,
-  sshClient: SSHClient
-): Promise<string | null> {
-  try {
-    const containerName = `${projectName}-${serviceName}`;
-    const result = await sshClient.exec(`docker inspect ${containerName} --format='{{.Image}}'`);
-    return result.trim() || null;
-  } catch (error) {
-    return null; // Container doesn't exist or error
-  }
-}
 
 /**
  * Determines if a service is built locally or uses external image
@@ -142,7 +125,7 @@ export async function createServiceFingerprint(
   const secretsHash = createSecretsHash(serviceEntry, secrets);
   
   if (isBuiltService(serviceEntry)) {
-    // Built service - get local image hash
+    // Built service - get local image hash directly from Docker
     const imageName = projectName ? `${projectName}-${serviceEntry.name}` : serviceEntry.name;
     const localImageHash = await getLocalImageHash(imageName);
     
@@ -199,19 +182,11 @@ export function shouldRedeploy(
   
   // For built services, check image hash (code changes) after config/secrets
   if (desired.type === 'built') {
-    if (current.localImageHash !== desired.localImageHash) {
+    // Compare local desired image with current server image
+    if (desired.localImageHash && current.serverImageHash !== desired.localImageHash) {
       return {
         shouldRedeploy: true,
         reason: 'image updated',
-        priority: 'normal'
-      };
-    }
-    
-    // Also check if server has different image
-    if (desired.serverImageHash && current.serverImageHash !== desired.serverImageHash) {
-      return {
-        shouldRedeploy: true,
-        reason: 'server image differs',
         priority: 'normal'
       };
     }
@@ -235,22 +210,3 @@ export function shouldRedeploy(
   };
 }
 
-/**
- * Enriches a fingerprint with server-side information
- */
-export async function enrichFingerprintWithServerInfo(
-  fingerprint: ServiceFingerprint,
-  serviceName: string,
-  projectName: string,
-  sshClient: SSHClient
-): Promise<ServiceFingerprint> {
-  if (fingerprint.type === 'built') {
-    const serverImageHash = await getServerImageHash(serviceName, projectName, sshClient);
-    return {
-      ...fingerprint,
-      serverImageHash: serverImageHash || undefined,
-    };
-  }
-  
-  return fingerprint;
-}

--- a/packages/cli/tests/service-fingerprint.test.ts
+++ b/packages/cli/tests/service-fingerprint.test.ts
@@ -6,8 +6,7 @@ import {
   ServiceFingerprint,
   createServiceFingerprint,
   isBuiltService,
-  getLocalImageHash,
-  getServerImageHash
+  getLocalImageHash
 } from '../src/utils/service-fingerprint';
 import { ServiceEntry, IopSecrets } from '../src/config/types';
 
@@ -311,17 +310,17 @@ describe('service-fingerprint', () => {
 
     it('should require redeploy when server image differs from local', () => {
       const current = { ...builtFingerprint, serverImageHash: 'sha256:server123' };
-      const desired = { ...builtFingerprint, serverImageHash: 'sha256:server456' };
+      const desired = { ...builtFingerprint, localImageHash: 'sha256:local456' };
       
       const result = shouldRedeploy(current, desired);
       
       expect(result.shouldRedeploy).toBe(true);
-      expect(result.reason).toBe('server image differs');
+      expect(result.reason).toBe('image updated');
       expect(result.priority).toBe('normal');
     });
 
     it('should not require redeploy when fingerprints match', () => {
-      const current = { ...builtFingerprint };
+      const current = { ...builtFingerprint, serverImageHash: 'sha256:image123' };
       const desired = { ...builtFingerprint };
       
       const result = shouldRedeploy(current, desired);


### PR DESCRIPTION
## Summary

Fixes services being incorrectly marked as "up-to-date, skipped" when they should redeploy due to image changes.

- Replaces label-based image hash tracking with direct Docker image inspection
- Resolves issue where containers missing `iop.local-image-hash` and `iop.server-image-hash` labels were not being redeployed
- Uses `docker inspect --format='{{.Id}}'` and `docker inspect container --format='{{.Image}}'` for reliable image hash comparison

## Root Cause

The original issue occurred because:

1. **Missing Labels**: Containers deployed before image hash labeling was fully implemented were missing the `iop.local-image-hash` and `iop.server-image-hash` labels
2. **Faulty Logic**: The comparison `undefined \!== "actual-hash"` should trigger redeployment but was not working correctly
3. **Label Dependency**: The system relied on stored metadata instead of actual Docker state

## Solution

**Direct Docker Inspection Approach:**

- **Current Server Image**: Extract from `containerConfig.Image` during container inspection  
- **Desired Local Image**: Get via `docker inspect --format='{{.Id}}' imageName:latest`
- **Comparison**: Direct hash comparison without label dependency
- **Backward Compatible**: Works with containers missing image hash labels

## Benefits

✅ **Eliminates label complexity** - no more missing label issues  
✅ **Uses actual Docker state** - more reliable than stored metadata  
✅ **Format consistency** - same inspection commands for both local and server  
✅ **Simpler logic** - direct hash comparison  
✅ **Robust** - works regardless of historical label presence  

## Changes Made

### Core Logic Updates
- **`getCurrentServiceFingerprint()`**: Use `containerConfig.Image` instead of labels for server image hash
- **`createServiceFingerprint()`**: Use `docker inspect --format='{{.Id}}'` for local image hash  
- **`shouldRedeploy()`**: Compare `desired.localImageHash` with `current.serverImageHash`

### Cleanup
- **Removed**: `iop.local-image-hash` and `iop.server-image-hash` label management
- **Removed**: `getServerImageHash()` and `enrichFingerprintWithServerInfo()` functions
- **Kept**: Config and secrets hash labels (still necessary for non-inspectable data)

## Test Plan

- [x] Code compiles successfully 
- [x] Local image hash extraction works (`docker inspect --format='{{.Id}}'`)
- [x] Image change detection works with different built images
- [ ] Full end-to-end deployment test (requires server access)

## Files Changed

- `packages/cli/src/commands/deploy.ts` - Updated `getCurrentServiceFingerprint()` 
- `packages/cli/src/commands/blue-green.ts` - Removed image hash label storage
- `packages/cli/src/utils/service-fingerprint.ts` - Core fingerprinting logic updates

Fixes #75

🤖 Generated with [Claude Code](https://claude.ai/code)