### PR TITLE
feat: add automatic disk cleanup during deployments

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1025,14 +1025,23 @@ async function deployServicesToServer(
 
     // Perform pre-deployment disk cleanup to prevent space issues
     const cleanupResult = await dockerClient.performPreDeploymentCleanup();
-    if (cleanupResult.cleaned) {
+    
+    const cleanupActions: string[] = [];
+    if (cleanupResult.tempFilesCleanedUp) {
+      cleanupActions.push("temp files");
+    }
+    if (cleanupResult.dockerImagesCleanedUp) {
+      cleanupActions.push("Docker images");
+    }
+    
+    if (cleanupActions.length > 0) {
       const spaceFreed = cleanupResult.spaceAfter - cleanupResult.spaceBefore;
       logger.verboseLog(
-        `[${serverHostname}] Disk cleanup completed: freed ${spaceFreed}GB (${cleanupResult.spaceBefore}GB → ${cleanupResult.spaceAfter}GB available)`
+        `[${serverHostname}] Cleaned up ${cleanupActions.join(" + ")}: freed ${spaceFreed}GB (${cleanupResult.spaceBefore}GB → ${cleanupResult.spaceAfter}GB available)`
       );
     } else {
       logger.verboseLog(
-        `[${serverHostname}] Disk cleanup skipped: ${cleanupResult.spaceAfter}GB available`
+        `[${serverHostname}] Cleanup skipped: ${cleanupResult.spaceAfter}GB available`
       );
     }
 

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1023,6 +1023,27 @@ async function deployServicesToServer(
       context.verboseFlag
     );
 
+    // Perform pre-deployment disk cleanup to prevent space issues
+    const cleanupResult = await dockerClient.performPreDeploymentCleanup();
+    if (cleanupResult.cleaned) {
+      const spaceFreed = cleanupResult.spaceAfter - cleanupResult.spaceBefore;
+      logger.verboseLog(
+        `[${serverHostname}] Disk cleanup completed: freed ${spaceFreed}GB (${cleanupResult.spaceBefore}GB → ${cleanupResult.spaceAfter}GB available)`
+      );
+    } else {
+      logger.verboseLog(
+        `[${serverHostname}] Disk cleanup skipped: ${cleanupResult.spaceAfter}GB available`
+      );
+    }
+
+    // Validate sufficient disk space after cleanup
+    if (cleanupResult.spaceAfter < 1) {
+      throw new Error(
+        `Insufficient disk space on ${serverHostname}: only ${cleanupResult.spaceAfter}GB available. ` +
+        `Please free up disk space manually or increase server storage.`
+      );
+    }
+
     // Deploy each service with appropriate strategy and collect results
     const results: ServiceDeploymentResult[] = [];
     for (let i = 0; i < services.length; i++) {

--- a/packages/cli/src/docker/index.ts
+++ b/packages/cli/src/docker/index.ts
@@ -1170,21 +1170,19 @@ EOF`);
     success: boolean;
     spaceBefore: number;
     spaceAfter: number;
-    cleaned: boolean;
+    tempFilesCleanedUp: boolean;
+    dockerImagesCleanedUp: boolean;
   }> {
     const spaceInfoBefore = await this.checkDiskSpace();
     
-    let cleaned = false;
+    // Always clean up temp files - they're just leftover artifacts
+    const tempFilesCleanedUp = await this.cleanupTempFiles();
     
-    // Only perform cleanup if disk usage is high (> 80%) or available space is low (< 2GB)
+    let dockerImagesCleanedUp = false;
+    
+    // Only perform Docker image cleanup if disk usage is high (> 80%) or available space is low (< 2GB)
     if (spaceInfoBefore.usedPercent > 80 || spaceInfoBefore.available < 2) {
-      cleaned = true;
-      
-      // Clean up old Docker images
-      await this.pruneImages();
-      
-      // Clean up temp files
-      await this.cleanupTempFiles();
+      dockerImagesCleanedUp = await this.pruneImages();
     }
     
     const spaceInfoAfter = await this.checkDiskSpace();
@@ -1193,7 +1191,8 @@ EOF`);
       success: true,
       spaceBefore: spaceInfoBefore.available,
       spaceAfter: spaceInfoAfter.available,
-      cleaned
+      tempFilesCleanedUp,
+      dockerImagesCleanedUp
     };
   }
 

--- a/packages/cli/src/docker/index.ts
+++ b/packages/cli/src/docker/index.ts
@@ -1099,6 +1099,105 @@ EOF`);
   }
 
   /**
+   * Prune all unused Docker images on the remote server.
+   */
+  async pruneImages(): Promise<boolean> {
+    try {
+      await this.execRemote("image prune -a -f");
+      return true;
+    } catch (error) {
+      this.logError(`Failed to prune Docker images: ${error}`);
+      return false;
+    }
+  }
+
+  /**
+   * Check available disk space and return info about usage
+   */
+  async checkDiskSpace(): Promise<{
+    available: number; // GB
+    used: number; // GB
+    total: number; // GB
+    usedPercent: number;
+  }> {
+    if (!this.sshClient) {
+      this.logError("SSH client not available for disk space check");
+      return { available: 0, used: 0, total: 0, usedPercent: 100 };
+    }
+    
+    try {
+      const output = await this.sshClient.exec("df -BG / | tail -1");
+      // Parse output like: /dev/vda1      25G   15G   10G  60% /
+      const parts = output.trim().split(/\s+/);
+      if (parts.length >= 6) {
+        const total = parseInt(parts[1].replace('G', ''));
+        const used = parseInt(parts[2].replace('G', ''));
+        const available = parseInt(parts[3].replace('G', ''));
+        const usedPercent = parseInt(parts[4].replace('%', ''));
+        
+        return { available, used, total, usedPercent };
+      }
+      throw new Error("Could not parse disk space output");
+    } catch (error) {
+      this.logError(`Failed to check disk space: ${error}`);
+      return { available: 0, used: 0, total: 0, usedPercent: 100 };
+    }
+  }
+
+  /**
+   * Clean up old iop deployment artifacts from /tmp
+   */
+  async cleanupTempFiles(): Promise<boolean> {
+    if (!this.sshClient) {
+      this.logError("SSH client not available for temp file cleanup");
+      return false;
+    }
+    
+    try {
+      await this.sshClient.exec("find /tmp -name 'iop-*.tar.gz' -mtime +1 -delete 2>/dev/null || true");
+      await this.sshClient.exec("find /tmp -name 'iop-*.tar' -mtime +1 -delete 2>/dev/null || true");
+      return true;
+    } catch (error) {
+      this.logError(`Failed to cleanup temp files: ${error}`);
+      return false;
+    }
+  }
+
+  /**
+   * Perform comprehensive disk cleanup before deployment
+   */
+  async performPreDeploymentCleanup(): Promise<{
+    success: boolean;
+    spaceBefore: number;
+    spaceAfter: number;
+    cleaned: boolean;
+  }> {
+    const spaceInfoBefore = await this.checkDiskSpace();
+    
+    let cleaned = false;
+    
+    // Only perform cleanup if disk usage is high (> 80%) or available space is low (< 2GB)
+    if (spaceInfoBefore.usedPercent > 80 || spaceInfoBefore.available < 2) {
+      cleaned = true;
+      
+      // Clean up old Docker images
+      await this.pruneImages();
+      
+      // Clean up temp files
+      await this.cleanupTempFiles();
+    }
+    
+    const spaceInfoAfter = await this.checkDiskSpace();
+    
+    return {
+      success: true,
+      spaceBefore: spaceInfoBefore.available,
+      spaceAfter: spaceInfoAfter.available,
+      cleaned
+    };
+  }
+
+  /**
    * Inspect a container and return its configuration
    */
   async inspectContainer(containerName: string): Promise<any> {


### PR DESCRIPTION
## Summary
Resolves server disk space issues during deployments by implementing automatic cleanup functionality.

## Changes Made
- **Always clean temp files**: Removes old iop deployment artifacts from `/tmp` (iop-*.tar.gz files older than 1 day) on every deployment
- **Conditional Docker image cleanup**: Runs `docker image prune -a -f` only when disk usage >80% or available space <2GB (can free up 43GB+ as mentioned in the issue)
- **Pre-deployment disk space check**: Validates sufficient disk space before starting deployments
- **Smart cleanup logic**: Avoids expensive operations when unnecessary while always cleaning up leftover artifacts
- **Detailed logging**: Shows exactly which cleanup actions were performed (temp files vs Docker images)

## How It Works
1. **Always**: Cleans up old deployment artifacts from `/tmp` (temp files older than 1 day)
2. **When space is low** (>80% usage or <2GB available): Also removes unused Docker images
3. **Validation**: After cleanup, ensures sufficient space (>1GB) is available for deployment
4. **Graceful failure**: If still insufficient space, deployment fails with clear error message

## Example Output
```
[server] Cleaned up temp files: freed 0GB (32GB → 32GB available)        # When space is sufficient
[server] Cleaned up temp files + Docker images: freed 15GB (2GB → 17GB available)  # When space was low
```

## Testing
- ✅ Verified temp files are always cleaned up regardless of disk space
- ✅ Confirmed Docker image cleanup only runs when space is actually needed
- ✅ Tested with sufficient disk space (32GB) - only temp cleanup ran
- ✅ Validated TypeScript compilation and deployment flow integration

## Impact
- **Prevents deployment failures** due to "no space left on device" errors
- **Always removes deployment artifacts** - no more lingering temp files
- **Efficient resource usage** - expensive Docker cleanup only when needed
- **Zero configuration required** - works automatically for all deployments

Fixes #77

🤖 Generated with [Claude Code](https://claude.ai/code)