### PR TITLE
feat: implement Docker logging configuration for log rotation

### DIFF
--- a/packages/cli/src/commands/blue-green.ts
+++ b/packages/cli/src/commands/blue-green.ts
@@ -1,5 +1,5 @@
 import { ServiceEntry, IopSecrets } from "../config/types";
-import { DockerClient, DockerContainerOptions } from "../docker";
+import { DockerClient, DockerContainerOptions, createServiceLoggingConfig } from "../docker";
 import {
   serviceNeedsBuilding,
   getServiceImageName,
@@ -64,6 +64,9 @@ function createBlueGreenContainerOptions(
   // Dual alias approach: generic name for internal communication + project-specific for proxy routing
   const projectSpecificAlias = `${projectName}-${serviceEntry.name}`;
 
+  // Add logging configuration for user services
+  const loggingConfig = createServiceLoggingConfig();
+
   return {
     name: containerName,
     image: imageNameWithRelease,
@@ -77,6 +80,8 @@ function createBlueGreenContainerOptions(
     ],
     restart: "unless-stopped",
     command: serviceEntry.command,
+    logDriver: loggingConfig.logDriver,
+    logOpts: loggingConfig.logOpts,
     labels: {
       "iop.managed": "true",
       "iop.project": projectName,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -26,6 +26,7 @@ import {
   DockerClient,
   DockerBuildOptions,
   DockerContainerOptions,
+  createServiceLoggingConfig,
 } from "../docker";
 
 // Deployment result tracking
@@ -145,6 +146,9 @@ function serviceEntryToContainerOptions(
     imageName = serviceEntry.image!;
   }
 
+  // Add logging configuration for user services
+  const loggingConfig = createServiceLoggingConfig();
+
   return {
     name: containerName,
     image: imageName,
@@ -155,6 +159,8 @@ function serviceEntryToContainerOptions(
     networkAliases: [serviceEntry.name], // Allow other containers to reach this service by name (e.g. "db", "meilisearch")
     restart: "unless-stopped",
     configHash, // Add for comparison
+    logDriver: loggingConfig.logDriver,
+    logOpts: loggingConfig.logOpts,
     labels: {
       "iop.managed": "true",
       "iop.project": projectName,

--- a/packages/cli/src/docker/index.ts
+++ b/packages/cli/src/docker/index.ts
@@ -28,6 +28,8 @@ export interface DockerContainerOptions {
   labels?: Record<string, string>;
   configHash?: string; // For Docker Compose-style change detection
   command?: string; // Override container command
+  logDriver?: string; // Log driver (e.g., 'json-file')
+  logOpts?: Record<string, string>; // Log driver options (e.g., max-size, max-file)
 }
 
 export interface DockerBuildOptions {
@@ -816,6 +818,17 @@ EOF`);
         });
       }
 
+      // Add logging configuration
+      if (options.logDriver) {
+        cmd += ` --log-driver ${options.logDriver}`;
+        
+        if (options.logOpts) {
+          Object.entries(options.logOpts).forEach(([key, value]) => {
+            cmd += ` --log-opt ${key}=${value}`;
+          });
+        }
+      }
+
       // Add the image
       cmd += ` ${options.image}`;
 
@@ -1260,6 +1273,11 @@ EOF`);
         }
       });
     }
+
+    // Add logging configuration for user services
+    const loggingConfig = createServiceLoggingConfig();
+    options.logDriver = loggingConfig.logDriver;
+    options.logOpts = loggingConfig.logOpts;
 
     return options;
   }
@@ -2004,4 +2022,36 @@ EOF`);
       return null;
     }
   }
+}
+
+/**
+ * Create logging configuration for proxy containers (5MB max size, 5 files)
+ */
+export function createProxyLoggingConfig(): {
+  logDriver: string;
+  logOpts: Record<string, string>;
+} {
+  return {
+    logDriver: "json-file",
+    logOpts: {
+      "max-size": "5m",
+      "max-file": "5"
+    }
+  };
+}
+
+/**
+ * Create logging configuration for user service containers (10MB max size, 3 files)
+ */
+export function createServiceLoggingConfig(): {
+  logDriver: string;
+  logOpts: Record<string, string>;
+} {
+  return {
+    logDriver: "json-file",
+    logOpts: {
+      "max-size": "10m",
+      "max-file": "3"
+    }
+  };
 }

--- a/packages/cli/src/setup-proxy/index.ts
+++ b/packages/cli/src/setup-proxy/index.ts
@@ -1,4 +1,4 @@
-import { DockerClient } from "../docker";
+import { DockerClient, createProxyLoggingConfig } from "../docker";
 import { IopConfig, IopSecrets } from "../config/types";
 import { SSHClient } from "../ssh";
 import { loadConfig } from "../config";
@@ -172,7 +172,8 @@ export async function setupIopProxy(
       return false;
     }
 
-    // Create container options
+    // Create container options with proxy logging configuration
+    const loggingConfig = createProxyLoggingConfig();
     const containerOptions = {
       name: IOP_PROXY_NAME,
       image: proxyImage,
@@ -183,6 +184,8 @@ export async function setupIopProxy(
         "/var/run/docker.sock:/var/run/docker.sock",
       ],
       restart: "always",
+      logDriver: loggingConfig.logDriver,
+      logOpts: loggingConfig.logOpts,
     };
 
     // Create and start the container

--- a/packages/cli/tests/docker-logging.test.ts
+++ b/packages/cli/tests/docker-logging.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'bun:test';
+import { createProxyLoggingConfig, createServiceLoggingConfig, DockerClient } from '../src/docker';
+import { ServiceEntry, IopSecrets } from '../src/config/types';
+
+describe('Docker Logging Configuration', () => {
+  it('should create proxy logging configuration with correct values', () => {
+    const config = createProxyLoggingConfig();
+    
+    expect(config.logDriver).toBe('json-file');
+    expect(config.logOpts['max-size']).toBe('5m');
+    expect(config.logOpts['max-file']).toBe('5');
+  });
+
+  it('should create service logging configuration with correct values', () => {
+    const config = createServiceLoggingConfig();
+    
+    expect(config.logDriver).toBe('json-file');
+    expect(config.logOpts['max-size']).toBe('10m');
+    expect(config.logOpts['max-file']).toBe('3');
+  });
+
+  it('should include logging configuration in service container options', () => {
+    const serviceEntry: ServiceEntry = {
+      name: 'test-service',
+      image: 'nginx:latest'
+    };
+    
+    const secrets: IopSecrets = {};
+    const projectName = 'test-project';
+    
+    const containerOptions = DockerClient.serviceToContainerOptions(
+      serviceEntry,
+      projectName,
+      secrets
+    );
+    
+    expect(containerOptions.logDriver).toBe('json-file');
+    expect(containerOptions.logOpts).toBeDefined();
+    expect(containerOptions.logOpts!['max-size']).toBe('10m');
+    expect(containerOptions.logOpts!['max-file']).toBe('3');
+  });
+});


### PR DESCRIPTION
## Summary

Implements Docker logging configuration to prevent unlimited log growth and improve performance as specified in #79.

- **Proxy containers**: 5MB max log size, 5 files rotation (25MB total)
- **User service containers**: 10MB max log size, 3 files rotation (30MB total)

## Changes Made

### Core Implementation
- Added `logDriver` and `logOpts` fields to `DockerContainerOptions` interface
- Created helper functions `createProxyLoggingConfig()` and `createServiceLoggingConfig()`
- Updated docker run command generation to include `--log-driver` and `--log-opt` flags

### Applied Across All Container Creation Paths
- **setup-proxy**: Proxy containers get 5MB/5 files configuration
- **deploy**: Service containers get 10MB/3 files configuration via `serviceToContainerOptions`
- **blue-green**: Zero-downtime deployments get 10MB/3 files via `createBlueGreenContainerOptions`

### Testing
- Added comprehensive unit tests verifying logging configuration values
- Tests confirm proper integration with existing container creation logic

## Benefits

✅ **Prevents disk space issues**: Limits total log storage to 25MB for proxy, 30MB for services  
✅ **Improves performance**: Faster `docker logs` commands with smaller log files  
✅ **Automatic rotation**: Uses Docker's built-in json-file driver with rotation  
✅ **Zero-downtime safe**: Applied to all deployment paths including blue-green  

## Technical Details

Uses Docker's `json-file` log driver with:
- `max-size`: Maximum size per log file before rotation
- `max-file`: Maximum number of rotated log files to keep

This provides automatic log rotation without requiring external log management tools.

Resolves #79

🤖 Generated with [Claude Code](https://claude.ai/code)