### PR TITLE
feat: add uploading step for built services

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -1177,14 +1177,28 @@ async function deployServiceWithStrategy(
     `Service ${service.name} needs deployment: ${redeployDecision.reason} (${redeployDecision.priority})`
   );
 
-  // Start service deployment logging
+  // Start service deployment logging - first show uploading if needed
   const strategy = getDeploymentStrategy(service);
-  const strategyText = strategy === 'zero-downtime' ? 'zero-downtime deployment' : 'stop-start deployment';
-  const deploymentStartTime = Date.now();
-  logger.serviceDeploymentStep(service.name, strategyText, isLastService);
+  let deploymentStartTime = Date.now();
+  
+  // Show uploading step if this service needs a built image
+  if (serviceNeedsBuilding(service)) {
+    logger.serviceDeploymentStep(service.name, 'uploading', isLastService);
+    await ensureServiceImageAvailable(service, context, dockerClient, sshClient);
+    
+    const uploadDuration = Date.now() - deploymentStartTime;
+    logger.serviceDeploymentComplete(service.name, 'uploading', uploadDuration, isLastService);
+    
+    // Reset start time for the actual deployment step
+    deploymentStartTime = Date.now();
+  } else {
+    // Ensure image is available for pre-built services (no upload needed)
+    await ensureServiceImageAvailable(service, context, dockerClient, sshClient);
+  }
 
-  // Ensure image is available
-  await ensureServiceImageAvailable(service, context, dockerClient, sshClient);
+  // Now show the deployment strategy step
+  const strategyText = strategy === 'zero-downtime' ? 'zero-downtime deployment' : 'stop-start deployment';
+  logger.serviceDeploymentStep(service.name, strategyText, isLastService);
 
   // Choose deployment strategy
   if (strategy === 'zero-downtime') {


### PR DESCRIPTION
## Summary

- Add "uploading..." step before zero-downtime deployment for services built locally
- Separate timing for upload vs deployment phases for better user feedback
- Only shows uploading step for services that need building (not pre-built images)

## Problem

When deploying locally built services, users see "zero-downtime deployment" but may wait 30-45 seconds with no feedback while the Docker image is being uploaded to the server. This creates confusion about what's happening during the deployment.

## Solution

Shows two distinct steps for built services:
1. `serviceName → uploading (X.Xs)`
2. `serviceName → zero-downtime deployment (Y.Ys)`

Pre-built services (pulled from registry) skip the upload step and go directly to deployment.

## Test plan

- [ ] Deploy a service that needs building - should show uploading step first
- [ ] Deploy a pre-built service - should skip uploading step
- [ ] Verify timing is tracked separately for upload and deployment phases

🤖 Generated with [Claude Code](https://claude.ai/code)