### PR TITLE
Fix inconsistent service logging format

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -732,7 +732,7 @@ async function buildServiceImage(
 
   try {
     // Build the image
-    logger.buildStep(`Build ${serviceEntry.name} image`, isLastService);
+    logger.buildStep(`${serviceEntry.name} → building image`, isLastService);
     const buildStartTime = Date.now();
 
     const imageReady = await buildOrTagServiceImage(
@@ -743,7 +743,7 @@ async function buildServiceImage(
     if (!imageReady) throw new Error("Image build failed");
 
     const buildDuration = Date.now() - buildStartTime;
-    logger.buildStepComplete(`Build ${serviceEntry.name} image`, buildDuration, isLastService);
+    logger.buildStepComplete(`${serviceEntry.name} → building image`, buildDuration, isLastService);
   } catch (error) {
     logger.error(`${serviceEntry.name} image build failed`, error);
     throw error;


### PR DESCRIPTION
## Summary

- Fixes inconsistent logging format between "Building locally" and "Deploying services" phases
- Both phases now consistently start each row with the service name

## Changes

**Before:**
```
[✓] Building locally
  ├─ [✓] Build web image (49.7s)
  └─ [✓] Build cron image (1.1s)
[✓] Deploying services
  ├─ [✓] web → uploading (113.2s)
  ├─ [✓] web → zero-downtime deployment (3.2s)
  └─ [✓] cron → up-to-date, skipped
```

**After:**
```
[✓] Building locally
  ├─ [✓] web → building image (49.7s)
  └─ [✓] cron → building image (1.1s)
[✓] Deploying services
  ├─ [✓] web → uploading (113.2s)
  ├─ [✓] web → zero-downtime deployment (3.2s)
  └─ [✓] cron → up-to-date, skipped
```

## Test plan

- [x] Build project successfully
- [ ] Test with multiple services to verify consistent formatting
- [ ] Ensure no functional changes to deployment logic

🤖 Generated with [Claude Code](https://claude.ai/code)